### PR TITLE
specify tldextract version to make things work

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,4 +27,4 @@ fire==0.3.1
 beautifulsoup4==4.9.3
 IPy==1.01
 selenium==4.0.0a1
-tldextract
+tldextract==4.0.0


### PR DESCRIPTION
solve error "TypeError: 'ExtractResult' object is not subscriptable" 

ref: https://github.com/john-kurkowski/tldextract/blob/master/CHANGELOG.md#500-2023-10-11